### PR TITLE
Handle eslint-disable before detemplatizing

### DIFF
--- a/detemplatize.js
+++ b/detemplatize.js
@@ -7,11 +7,13 @@ function replace_with_comments(match) {
 }
 
 module.exports = function (text) {
+  // /* eslint-disable */anything/* eslint-enable */ is removed
   // {# comments #} is replaced with a /* ... */
   // {% anything %} is replaced with a /* ... */
   // {% raw xxx %} is replaced with a {/* ... */} -- this is typically assigned to a variable
   // {{ anything }} is replaced with a {/* ... */} -- this is typically assigned to a variable
   return text
+    .replace(/\/\*\s*eslint-disable\s*\*\/[\s\S]*?(\/\*\s*eslint-enable\s*\*\/|$)/g, '')
     .replace(/{#[\s\S]*?#}/g, replace_with_comments)
     .replace(/{%\s*raw\s[\s\S]*?%}/g, replace_with_obj)
     .replace(/{%[\s\S]*?%}/g, replace_with_comments)

--- a/test/index.js
+++ b/test/index.js
@@ -48,6 +48,18 @@ describe('preprocess', function() {
     expect(detemplatize(source)).to.deep.equal(target)
   })
 
+  it('discards code between eslint-disable .. eslint-enable', function() {
+    var source = 'foo({{x}});/*  eslint-disable */x{{y}} = 1;/* eslint-enable  */bar({{x}});'
+    var target = 'foo({/**/});bar({/**/});'
+    expect(detemplatize(source)).to.deep.equal(target)
+  })
+
+  it('discards code after eslint-disable', function() {
+    var source = 'foo({{x}});/* eslint-disable */x{{y}} = 1;'
+    var target = 'foo({/**/});'
+    expect(detemplatize(source)).to.deep.equal(target)
+  })
+
   it('', function () {
     var source = '{% if true %}\nvar x = 1{% else %}var x = 2{% endif %}'
     var target = '/*         */\nvar x = 1/*      */var x = 2/*       */'


### PR DESCRIPTION
This allows /* eslint-disable */ to bypass problems
during detemplatizing.